### PR TITLE
Add \ core extension word

### DIFF
--- a/coreext.sh
+++ b/coreext.sh
@@ -108,3 +108,9 @@ zero_greater() { # 0>
   fi
 }
 builtin '0>' zero_greater
+
+backslash() { # \
+  while inbufget xc; do :; done
+}
+builtin '\' backslash
+immediate


### PR DESCRIPTION
Not sure if `builtin "\\\\" backslash` or `builtin "\\" backslash` would be proper with extra quoting done within `builtin`?